### PR TITLE
fix: allow "cypress run" arguments

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,9 +10,12 @@ const Bluebird = require('bluebird')
 // if there is an .env file, lots it and add to process.env
 require('dotenv').config()
 
-const args = arg({
-  '-n': Number,
-})
+const args = arg(
+  {
+    '-n': Number,
+  },
+  { permissive: true },
+)
 
 const repeatNtimes = args['-n'] ? args['-n'] : 1
 


### PR DESCRIPTION
- closes #4 

By default, the arg module doesn't allow unconfigured arguments so it doesn't seem possible to run this package with cypress run args. Here is an example:

Before:

```
$ DEBUG=cypress-repeat npx cypress-repeat run -n 50 --env KUBECONFIG=/home/brandonc/kubeconfig.yaml --project foo
Unknown or unexpected option: --env
```

After:

```
$ DEBUG=cypress-repeat npx cypress-repeat run -n 50 --env KUBECONFIG=/home/brandonc/kubeconfig.yaml --project foo
will repeat Cypress run 50 time(s)
  cypress-repeat parsing Cypress CLI [ 'cypress', 'run', '--env', 'KUBECONFIG=/home/brandonc/kubeconfig.yaml, '--project', 'foo'] +0ms
  cypress-repeat parsed CLI options { env: 'KUBECONFIG=/home/brandonc/kubeconfig.yaml, project: 'foo' } +3ms
***** repeat 1 of 50 *****
...
```
