### PR TITLE
spec use absolute instead of relative path

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ parseArguments()
         if (rerunFailedOnly && !isLastRun) {
           const failedSpecs = testResults.runs
             .filter((run) => run.stats.failures != 0)
-            .map((run) => run.spec.relative)
+            .map((run) => run.spec.absolute)
             .join(',')
 
           if (failedSpecs.length) {


### PR DESCRIPTION
Hello  there,
thank you for this work, it much easier to setup and maintain then cypresses own test case level retries.

I stumbled upon a path issue on a monorepo setup, and changing the spec path from relative to absolute fixes the issue

