### PR TITLE
add a --force flag to continue running through all iterations even if a test fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ You can rerun only the specs that failed
 npx cypress-repeat run -n <N> --until-passes --rerun-failed-only ... rest of "cypress run" arguments
 ```
 
+### Rerun only failed Specs
+
+You can force continue running through all iterations even if a test fails
+
+```shell
+npx cypress-repeat run -n <N> --force ... rest of "cypress run" arguments
+```
+
 ### Env variables
 
 Every run has two utility variables injected

--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ const args = arg(
     '-n': Number,
     '--until-passes': Boolean,
     '--rerun-failed-only': Boolean,
+    '--force': Boolean,
   },
   { permissive: true },
 )
@@ -28,6 +29,7 @@ const repeatNtimes = '-n' in args ? args['-n'] : 1
 const untilPasses = '--until-passes' in args ? args['--until-passes'] : false
 const rerunFailedOnly =
   '--rerun-failed-only' in args ? args['--rerun-failed-only'] : false
+const forceContinue = '--force' in args ? args['--force'] : false
 
 console.log('%s will repeat Cypress command %d time(s)', name, repeatNtimes)
 
@@ -37,6 +39,10 @@ if (untilPasses) {
 
 if (rerunFailedOnly) {
   console.log('%s it only reruns specs which have failed', name)
+}
+
+if (forceContinue) {
+  console.log('%s will force continue through all iterations', name)
 }
 
 /**
@@ -117,8 +123,10 @@ parseArguments()
             allRunOptions[k + 1].spec = failedSpecs
           } else {
             console.log('%s there were no failed specs', name)
-            console.log('%s exiting', name)
-            process.exit(0)
+            if (!forceContinue) {
+              console.log('%s exiting', name)
+              process.exit(0)
+            }
           }
         }
 
@@ -126,7 +134,9 @@ parseArguments()
           // failed to even run Cypress tests
           if (testResults.failures) {
             console.error(testResults.message)
-            return process.exit(testResults.failures)
+            if (!forceContinue) {
+              return process.exit(testResults.failures)
+            }
           }
         }
 
@@ -141,14 +151,14 @@ parseArguments()
             process.exit(0)
           }
           console.error('%s run %d of %d failed', name, k + 1, n)
-          if (k === n - 1) {
+          if (!forceContinue && k === n - 1) {
             console.error('%s no more attempts left', name)
             process.exit(testResults.totalFailed)
           }
         } else {
           if (testResults.totalFailed) {
             console.error('%s run %d of %d failed', name, k + 1, n)
-            if (!rerunFailedOnly || isLastRun) {
+            if (!forceContinue && (!rerunFailedOnly || isLastRun)) {
               process.exit(testResults.totalFailed)
             }
           }
@@ -164,5 +174,7 @@ parseArguments()
   .catch((e) => {
     console.log('error: %s', e.message)
     console.error(e)
-    process.exit(1)
+    if (!forceContinue) {
+      process.exit(1)
+    }
   })

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "demo:twice": "node . run -n 2",
     "demo:until-passes": "node . run -n 2 --until-passes",
     "demo:rerun-failed-only": "node . run -n 2 --rerun-failed-only",
+    "demo:force": "node . run -n 2 --force",
     "semantic-release": "semantic-release"
   },
   "repository": {


### PR DESCRIPTION
At the moment, if a test fails, it will exit the process at the end of the current run, even if there are more iterations.  This PR adds a `--force` flag so that it will continue to run through all the iterations you specified, even if a test fails.  